### PR TITLE
Change PopupActivation so it doesn't move around as much

### DIFF
--- a/Karen/App.xaml
+++ b/Karen/App.xaml
@@ -35,7 +35,8 @@
             <tb:TaskbarIcon
                 x:Key="NotifyIcon"
                 IconSource="/favicon.ico"
-                PopupActivation="All"
+                PopupActivation="LeftOrRightClick"
+                NoLeftClickDelay="true"
                 ToolTipText="LANraragi for Windows">
 
                 <tb:TaskbarIcon.TrayPopup>


### PR DESCRIPTION
The tray popup will open at the mouse cursor on click but will reposition again to the mouse cursor shortly after I think due to the double-click wait timer. So moving your cursor will make the popup move too. Very small dumb thing.
Also right-click isn't "captured" by the icon so my Windows 10 tray right-click menu still pops up.

So this is a small fix for both of those things. Previously the tray icon would also trigger on middle-click and won't anymore but I doubt anyone actually middle-clicks icons for this to affect anyone.