### PR TITLE
Derive work area from pointer position rather than window position

### DIFF
--- a/Karen/App.xaml.cs
+++ b/Karen/App.xaml.cs
@@ -75,8 +75,8 @@ namespace Karen
                 unsafe
                 {
                     var hwnd = new HWND((void*)WindowNative.GetWindowHandle(Popup));
-                    var area = DisplayArea.GetFromWindowId(Popup.AppWindow.Id, DisplayAreaFallback.Primary);
                     var point = e.Point;
+                    var area = DisplayArea.GetFromPoint(new PointInt32(point.X, point.Y), DisplayAreaFallback.Primary);
 
                     var dpi = Popup.Content.XamlRoot?.RasterizationScale ?? (float)(PInvoke.GetDpiForWindow(hwnd) / (float)PInvoke.USER_DEFAULT_SCREEN_DPI);
 


### PR DESCRIPTION
Fixes popup getting stuck in the wrong display in a certain dual screen device (and probably other touch-based devices with external displays).