### PR TITLE
Initialize popup before creating the tray icon

### DIFF
--- a/Karen/App.xaml.cs
+++ b/Karen/App.xaml.cs
@@ -38,6 +38,12 @@ namespace Karen
                 return;
             }
 
+            Popup = new KarenPopup();
+            Popup.Closed += (sender, args) =>
+            {
+                TrayIcon.Dispose();
+            };
+
             TrayIcon = Resources["TrayIcon"].As<TaskbarIcon>();
             TrayIcon.IconSource = new BitmapImage(new Uri("ms-appx:///Assets/favicon.ico"));
             TrayIcon.ForceCreate();
@@ -53,12 +59,6 @@ namespace Karen
             {
                 TrayIcon.ShowNotification("LANraragi", "The Launcher is now running! Please click the icon in your Taskbar.");
             }
-
-            Popup = new KarenPopup();
-            Popup.Closed += (sender, args) =>
-            {
-                TrayIcon.Dispose();
-            };
 
             if (Service.Settings.FirstLaunch)
             {

--- a/Karen/Karen.csproj
+++ b/Karen/Karen.csproj
@@ -58,7 +58,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4948" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250606001" />
-    <PackageReference Include="WinUIEx" Version="2.6.0" />
+    <PackageReference Include="WinUIEx" Version="2.7.0" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
Should prevent the app from crashing by users trying to open it before it's ready.