### PR TITLE
Bump nugets to non-broken versions

### DIFF
--- a/Karen/App.xaml.cs
+++ b/Karen/App.xaml.cs
@@ -43,7 +43,7 @@ namespace Karen
 
             Popup = new KarenPopup();
 
-            TrayIcon = new(1, "Assets/favicon.ico", "LANraragi for Windows")
+            TrayIcon = new(1, Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "Assets/favicon.ico")), "LANraragi for Windows")
             {
                 IsVisible = true
             };

--- a/Karen/Karen.csproj
+++ b/Karen/Karen.csproj
@@ -51,23 +51,23 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.3.260402-preview2" />
     <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.3.260402-preview2" />
-    <PackageReference Include="DesktopFlyouts.WinUI" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.287">
+    <PackageReference Include="DesktopFlyouts.WinUI" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.298">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" Version="2.2.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="2.2.1" />
-    <PackageReference Include="WinUIEx" Version="2.9.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2526" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" Version="2.3.1" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="2.3.0" />
+    <PackageReference Include="WinUIEx" Version="2.9.2" />
     <!-- We don't need ANY of this -->
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="*" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.AI" Version="*" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.DWrite" Version="*" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.ML" Version="*" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.Widgets" Version="*" ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" Version="*" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.AI" Version="2.3.4" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.DWrite" Version="2.1.0" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.ML" Version="2.1.74" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.Widgets" Version="2.0.5" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.Windows.AI.MachineLearning" Version="2.2.12" ExcludeAssets="all" />
     <PackageReference Include="System.Numerics.Tensors" Version="*" ExcludeAssets="all" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="*" ExcludeAssets="all" />
   </ItemGroup>

--- a/Setup/Program.cs
+++ b/Setup/Program.cs
@@ -114,7 +114,7 @@ namespace Setup
                 var pm = new PackageManager();
 
                 // Taken from the MSIX version field and it's the same across all packages
-                var targetVersion = new Version(2, 2, 0, 0);
+                var targetVersion = new Version(2, 3, 1, 0);
 
                 var foundFramework = pm.FindPackagesForUser(string.Empty, "Microsoft.WindowsAppRuntime.2_8wekyb3d8bbwe").Any(pkg => pkg.Id.Version.ToVersion() >= targetVersion && pkg.Id.Architecture == Windows.System.ProcessorArchitecture.X64);
                 var foundMain = pm.FindPackagesForUser(string.Empty, "MicrosoftCorporationII.WinAppRuntime.Main.2_8wekyb3d8bbwe").Any(pkg => pkg.Id.Version.ToVersion() >= targetVersion && pkg.Id.Architecture == Windows.System.ProcessorArchitecture.X64);

--- a/Setup/Setup.csproj
+++ b/Setup/Setup.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.Contracts">
-      <Version>10.0.28000.1839</Version>
+      <Version>10.0.28000.2526</Version>
     </PackageReference>
     <PackageReference Include="WixSharp">
       <Version>1.26.0</Version>


### PR DESCRIPTION
Title. They also broke Package.Current in unpackaged scenarios so I had to specify the full path to the ico for the trayicon because WinUIEx checks for Current but it throws now instead of returning null.
